### PR TITLE
Automatically set security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ changes in the central string and buffer implementations.
 * Marc Rahn (marc.rahn@sap.com)
 * Tobias Simolik (tobias.simolik@sap.com)
 * Hannah Keller (hannah.keller@sap.com)
+* Nils Neumann (nils.neumann@sap.com)
 
 #### Project Manager & Product Owner
 * Mathias Essenpreis (mathias.essenpreis@sap.com)

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -56,6 +56,10 @@ const hasOwnProperty = Function.call.bind(Object.prototype.hasOwnProperty);
 var RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
 var RE_TE_CHUNKED = common.chunkExpression;
 
+// TaintNode
+const contentType = require('taint/_contentTypeDetection');
+const securtiyHeaderOptions = require('taint/_securityHeaderOptions');
+
 // isCookieField performs a case-insensitive comparison of a provided string
 // against the word "cookie." As of V8 6.6 this is faster than handrolling or
 // using a case-insensitive RegExp.
@@ -105,6 +109,10 @@ function OutgoingMessage() {
   this[outHeadersKey] = null;
 
   this._onPendingData = noopPendingOutput;
+
+  // TaintNode
+  this._isHTML = null;
+  this.msgState = null;
 }
 util.inherits(OutgoingMessage, Stream);
 
@@ -208,6 +216,191 @@ OutgoingMessage.prototype.destroy = function destroy(error) {
 };
 
 
+// TaintNode
+OutgoingMessage.prototype.setSecurityHeaders =
+  function setSecurityHeaders(options) {
+    if (options && options.addHeaders !== undefined) {
+      if (options.headers !== undefined) {
+        OutgoingMessage.prototype._addSecurityHeaders = options;
+      } else {
+        OutgoingMessage.prototype._addSecurityHeaders.addHeaders =
+          options.addHeaders;
+      }
+    }
+    return OutgoingMessage.prototype._addSecurityHeaders;
+  };
+
+// TaintNode
+/*
+* Intercepts first data chunk running through the http module.
+* If the content-type is HTML, certain security headers will be added
+* to the HTTP message, securing the communication.
+*/
+
+OutgoingMessage.prototype.addSecurityHeadersAndFinishHeaders =
+function addSecurityHeadersAndFinishHeaders(setSecurityHeaders) {
+  const state = this.msgState;
+
+  if (!state)
+    return;
+
+  if (this._addSecurityHeaders.addHeaders) {
+    if (!this[outHeadersKey])
+      this[outHeadersKey] = {};
+
+    const headerOptions = this._addSecurityHeaders.headers;
+    /*
+    * Add Security Headers
+    */
+
+    // X-Powered-By (remove)
+    if (headerOptions['x-powered-by'] && this.hasHeader('x-powered-by')) {
+      const headers = state.header.split('\n');
+      for (var i = 0; i < headers.length; i++) {
+        if (headers[i].toLowerCase().startsWith('x-powered-by')) {
+          headers.splice(i, 1);
+          delete this[outHeadersKey]['x-powered-by'];
+          break;
+        }
+      }
+      state.header = headers.join('\n');
+    }
+
+    // Expect-CT
+    addHeaderIfNotSet(this, state, headerOptions,
+                      'Expect-CT', 'max-age=86400; enforce');
+
+    // Strit-Transport-Security
+    addHeaderIfNotSet(this, state, headerOptions,
+                      'Strict-Transport-Security',
+                      'max-age=31536000; includeSubdomains');
+
+    // Referrer-Policy
+    addHeaderIfNotSet(this, state, headerOptions,
+                      'Referrer-Policy', 'same-origin');
+
+    // X-Content-Type-Options
+    addHeaderIfNotSet(this, state, headerOptions,
+                      'X-Content-Type-Options', 'nosniff');
+
+    // X-DNS-Prefatch-Control
+    addHeaderIfNotSet(this, state, headerOptions,
+                      'X-DNS-Prefatch-Control', 'off');
+
+    // X-Permitted-Cross-Domain-Policies
+    addHeaderIfNotSet(this, state, headerOptions,
+                      'X-Permitted-Cross-Domain-Policies',
+                      'none');
+
+    // Feature-Policy
+    addHeaderIfNotSet(this, state, headerOptions,
+                      'Feature-Policy',
+                      'vibrate: none; geolocation: none');
+
+    // Public-Key-Pins
+    addHeaderIfNotSet(this, state, headerOptions,
+                      'Public-Key-Pins',
+                      'pin-sha256="klO23nT2ehFDXCfx ' +
+                      '3eHTDRESMz3asjlmuO4aIdjiuY="; ' +
+                      'max-age=2592000; includeSubDomain');
+
+    // Cache-Control
+    addHeaderIfNotSet(this, state, headerOptions, 'Cache-Control', 'no-cache');
+
+    if (this._isHTML) {
+      // Content-Type
+      const contentTypeName = 'Content-Type';
+      if (!this.hasHeader(contentTypeName)) {
+        const contentTypeValue = 'text/html';
+        processHeader(this, state, contentTypeName, contentTypeValue);
+        this[outHeadersKey][contentTypeName.toLowerCase()] =
+          [contentTypeName, contentTypeValue];
+      }
+
+      // Content-Security-Policy
+      addHeaderIfNotSet(this, state, headerOptions,
+                        'Content-Security-Policy',
+                        'script-src self; object-src self');
+
+      // X-Download-Options
+      addHeaderIfNotSet(this, state, headerOptions,
+                        'X-Download-Options', 'noopen');
+
+      // X-Frame-Options
+      addHeaderIfNotSet(this, state, headerOptions,
+                        'X-Frame-Options', 'deny');
+
+      // X-XSS-Protection
+      addHeaderIfNotSet(this, state, headerOptions,
+                        'X-XSS-Protection', '1; mode=block');
+    }
+  }
+
+  /*
+    Finish Headers
+  */
+  this._header = state.header + state.endHeader + CRLF;
+  this._headerSent = false;
+};
+
+function addHeaderIfNotSet(self, state,
+                           headerOptions, headerName, headerValue) {
+  if (headerOptions[headerName.toLowerCase()] && !self.hasHeader(headerName)) {
+    processHeader(self, state, headerName, headerValue);
+    self[outHeadersKey][headerName.toLowerCase()] =
+      [headerName, headerValue];
+  }
+}
+
+// TaintNode
+OutgoingMessage.prototype._sendChunk =
+  function _sendChunk(data, encoding, callback, len, crlf_buf) {
+    let headerToSent = '';
+
+    // This is a shameful hack to get the headers and first body chunk onto
+    // the same packet. Future versions of Node are going to take care of
+    // this at a lower level and in a more general way.
+    if (!this._headerSent) {
+      if (typeof data === 'string' &&
+         (encoding === 'utf8' || encoding === 'latin1' || !encoding)) {
+
+        // [BEGIN] TaintNode
+        /*
+        * Check if content-type is HTML and
+        * add security headers if this is the case.
+        */
+        if (this._isHTML === null) {
+          this._isHTML =
+            contentType.isHTML(data, this.getHeader('Content-Type'));
+        }
+
+        this.addSecurityHeadersAndFinishHeaders();
+        // [END] TaintNode
+
+        headerToSent = this._header;
+      } else {
+        var header = this._header;
+        if (this.output.length === 0) {
+          this.output = [header];
+          this.outputEncodings = ['latin1'];
+          this.outputCallbacks = [null];
+        } else {
+          this.output.unshift(header);
+          this.outputEncodings.unshift('latin1');
+          this.outputCallbacks.unshift(null);
+        }
+        this.outputSize += header.length;
+        this._onPendingData(header.length);
+      }
+      this._headerSent = true;
+    }
+
+    this._writeRaw(headerToSent + len.toString(16), 'latin1', null);
+    this._writeRaw(crlf_buf, null, null);
+    this._writeRaw(data, encoding, null);
+    return this._writeRaw(crlf_buf, null, callback);
+  };
+
 // This abstract either writing directly to the socket or buffering it.
 OutgoingMessage.prototype._send = function _send(data, encoding, callback) {
   // This is a shameful hack to get the headers and first body chunk onto
@@ -216,6 +409,20 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback) {
   if (!this._headerSent) {
     if (typeof data === 'string' &&
         (encoding === 'utf8' || encoding === 'latin1' || !encoding)) {
+
+      // [BEGIN] TaintNode
+      /*
+      * Check if content-type is HTML and
+      * add security headers if this is the case.
+      */
+      if (this._isHTML === null) {
+        this._isHTML =
+          contentType.isHTML(data, this.getHeader('Content-Type'));
+      }
+
+      this.addSecurityHeadersAndFinishHeaders();
+      // [END] TaintNode
+
       data = this._header + data;
     } else {
       var header = this._header;
@@ -292,7 +499,8 @@ function _storeHeader(firstLine, headers) {
     date: false,
     expect: false,
     trailer: false,
-    header: firstLine
+    header: firstLine,
+    endHeader: ''
   };
 
   var key;
@@ -314,11 +522,11 @@ function _storeHeader(firstLine, headers) {
     }
   }
 
-  let { header } = state;
+  let { endHeader } = state;
 
   // Date header
   if (this.sendDate && !state.date) {
-    header += 'Date: ' + utcDate() + CRLF;
+    endHeader += 'Date: ' + utcDate() + CRLF;
   }
 
   // Force the connection to close when the response is a 204 No Content or
@@ -348,10 +556,10 @@ function _storeHeader(firstLine, headers) {
     const shouldSendKeepAlive = this.shouldKeepAlive &&
         (state.contLen || this.useChunkedEncodingByDefault || this.agent);
     if (shouldSendKeepAlive) {
-      header += 'Connection: keep-alive\r\n';
+      endHeader += 'Connection: keep-alive\r\n';
     } else {
       this._last = true;
-      header += 'Connection: close\r\n';
+      endHeader += 'Connection: close\r\n';
     }
   }
 
@@ -364,9 +572,9 @@ function _storeHeader(firstLine, headers) {
     } else if (!state.trailer &&
                !this._removedContLen &&
                typeof this._contentLength === 'number') {
-      header += 'Content-Length: ' + this._contentLength + CRLF;
+      endHeader += 'Content-Length: ' + this._contentLength + CRLF;
     } else if (!this._removedTE) {
-      header += 'Transfer-Encoding: chunked\r\n';
+      endHeader += 'Transfer-Encoding: chunked\r\n';
       this.chunkedEncoding = true;
     } else {
       // We should only be able to get here if both Content-Length and
@@ -384,12 +592,20 @@ function _storeHeader(firstLine, headers) {
     throw new ERR_HTTP_TRAILER_INVALID();
   }
 
-  this._header = header + CRLF;
+  // Important to set msg._header to not invoke implicitHeaders()
+  state.endHeader = endHeader;
+  this._header = state.header + state.endHeader + CRLF;
+
   this._headerSent = false;
+
+  this.msgState = state;
 
   // wait until the first body chunk, or close(), is sent to flush,
   // UNLESS we're sending Expect: 100-continue.
-  if (state.expect) this._send('');
+  if (state.expect) {
+    this._header = state.header + state.endHeader + CRLF;
+    this._send('');
+  }
 }
 
 function processHeader(self, state, key, value, validate) {
@@ -617,10 +833,7 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
     else
       len = chunk.length;
 
-    msg._send(len.toString(16), 'latin1', null);
-    msg._send(crlf_buf, null, null);
-    msg._send(chunk, encoding, null);
-    ret = msg._send(crlf_buf, null, callback);
+    ret = msg._sendChunk(chunk, encoding, callback, len, crlf_buf);
   } else {
     ret = msg._send(chunk, encoding, callback);
   }
@@ -827,6 +1040,10 @@ OutgoingMessage.prototype.pipe = function pipe() {
   // OutgoingMessage should be write-only. Piping from it is disabled.
   this.emit('error', new ERR_STREAM_CANNOT_PIPE());
 };
+
+// TaintNode
+OutgoingMessage.prototype._addSecurityHeaders =
+  securtiyHeaderOptions.getSecurityHeaderOptions();
 
 module.exports = {
   OutgoingMessage

--- a/lib/taint/_contentTypeDetection.js
+++ b/lib/taint/_contentTypeDetection.js
@@ -1,0 +1,45 @@
+// TaintNode
+'use strict';
+
+// Return true, if the provided data is a HTML fragment
+// Algorithm and signatures are described here (modified):
+// https://mimesniff.spec.whatwg.org/
+
+const patterns = [
+  '<!DOCTYPE HTML', '<HTML', '<HEAD', '<SCRIPT', '<IFRAME', '<H1',
+  '<DIV', '<FONT', '<TABLE', '<A', '<STYLE', '<TITLE', '<B', '<BODY',
+  '<BR', '<P', '<!--'
+];
+
+function isHTML(data, contentType) {
+  if (typeof data !== 'string')
+    return false;
+
+  if (contentType === undefined) {
+    for (var i = 0; i < patterns.length; i++) {
+      if (matchesPattern(data.toUpperCase(), patterns[i]))
+        return true;
+    }
+  } else if (contentType === 'text/html' ||
+      contentType === 'application/xml+html') {
+    return true;
+  }
+
+  return false;
+}
+
+function matchesPattern(input, pattern) {
+  if (input.length < pattern.length)
+    return false;
+
+  input = input.trim();
+
+  for (var p = 0; p < pattern.length; p++) {
+    if (input[p] !== pattern[p])
+      return false;
+  }
+
+  return true;
+}
+
+exports.isHTML = isHTML;

--- a/lib/taint/_securityHeaderOptions.js
+++ b/lib/taint/_securityHeaderOptions.js
@@ -1,0 +1,134 @@
+'use strict';
+
+function getEnvVarOptions() {
+  return (typeof process.env.SECURITYHEADER === 'string') ?
+    JSON.parse(process.env.SECURITYHEADER) :
+    process.env.securityHeader;
+}
+
+function getNpmPackageOptions() {
+  const env = process.env;
+
+  const addHeaders = env.npm_package_securityHeader_addHeaders;
+  const poweredBy = env.npm_package_securityHeader_headers_x_powered_by;
+  const expectCT = env.npm_package_securityHeader_headers_expect_ct;
+  const referrerPolicy =
+    env.npm_package_securityHeader_headers_referrer_policy;
+  const strictTransport =
+    env.npm_package_securityHeader_headers_strict_transport_security;
+  const dnsPrefatch =
+    env.npm_package_securityHeader_headers_x_dns_prefatch_control;
+  const crossDomain =
+    env.npm_package_securityHeader_headers_x_permitted_cross_domain_policies;
+  const contentType =
+    env.npm_package_securityHeader_headers_x_content_type_options;
+  const securityPolicy =
+    env.npm_package_securityHeader_headers_content_security_policy;
+  const downloadOptions =
+    env.npm_package_securityHeader_headers_x_download_options;
+  const frameOptions =
+    env.npm_package_securityHeader_headers_x_frame_options;
+  const xssProtection =
+    env.npm_package_securityHeader_headers_x_xss_protection;
+  const featurePolicy =
+    env.npm_package_securityHeader_headers_feature_policy;
+  const publicKeys =
+    env.npm_package_securityHeader_headers_public_key_pins;
+  const cacheControl =
+    env.npm_package_securityHeader_headers_cache_control;
+
+  const options =
+    { 'addHeaders': addHeaders,
+      'headers':
+      { 'x-powered-by': poweredBy,
+        'expect-ct': expectCT,
+        'strict-transport-security': strictTransport,
+        'referrer-policy': referrerPolicy,
+        'x-dns-prefatch-control': dnsPrefatch,
+        'x-permitted-cross-domain-policies': crossDomain,
+        'x-content-type-options': contentType,
+        'content-security-policy': securityPolicy,
+        'x-download-options': downloadOptions,
+        'x-frame-options': frameOptions,
+        'x-xss-protection': xssProtection,
+        'feature-policy': featurePolicy,
+        'public-key-pins': publicKeys,
+        'cache-control': cacheControl
+      }
+    };
+
+  return options;
+}
+
+function getDefaultValues() {
+  const defaultValues =
+  [
+    { 'name': 'x-powered-by', 'value': true },
+    { 'name': 'expect-ct', 'value': true },
+    { 'name': 'referrer-policy', 'value': true },
+    { 'name': 'strict-transport-security', 'value': true },
+    { 'name': 'x-dns-prefatch-control', 'value': true },
+    { 'name': 'x-permitted-cross-domain-policies', 'value': false },
+    { 'name': 'x-content-type-options', 'value': true },
+    { 'name': 'content-security-policy', 'value': false },
+    { 'name': 'x-download-options', 'value': true },
+    { 'name': 'x-frame-options', 'value': true },
+    { 'name': 'x-xss-protection', 'value': true },
+    { 'name': 'feature-policy', 'value': false },
+    { 'name': 'public-key-pins', 'value': false },
+    { 'name': 'cache-control', 'value': false }
+  ];
+
+  return defaultValues;
+}
+
+function getsecurityHeaderOptions() {
+  // Get default values
+  const defaultValues = getDefaultValues();
+
+  // Get values from env variable "SECURITYHEADER"
+  const envVar = getEnvVarOptions();
+  let envVarAddHeaders;
+  let envHeaders = '';
+  if (envVar !== undefined) {
+    envVarAddHeaders = envVar.addHeaders;
+    envHeaders = envVar.headers;
+  }
+
+  // Get values from package.json
+  const options = getNpmPackageOptions();
+
+  let npmAddHeaders;
+  let npmHeaders = '';
+  if (options !== undefined) {
+    npmAddHeaders = options.addHeaders;
+    npmHeaders = options.headers;
+  }
+
+  // Check if values are present and if not set them to default value
+  options.addHeaders =
+    checkOptionValue(npmAddHeaders,
+                     envVarAddHeaders, true);
+
+  for (var i = 0; i < defaultValues.length; i++) {
+    options.headers[defaultValues[i].name] =
+      checkOptionValue(npmHeaders[defaultValues[i].name],
+                       envHeaders[defaultValues[i].name],
+                       defaultValues[i].value);
+  }
+
+  return options;
+}
+
+function checkOptionValue(packageVariable, envVariable, defaultValue) {
+  if (packageVariable === undefined) {
+    if (envVariable !== undefined)
+      return envVariable;
+  } else {
+    return JSON.parse(packageVariable.toLowerCase());
+  }
+
+  return defaultValue;
+}
+
+exports.getSecurityHeaderOptions = getsecurityHeaderOptions;

--- a/node.gyp
+++ b/node.gyp
@@ -37,6 +37,7 @@
       'lib/taint/_pg.js',
       'lib/taint/pg_lexer.js',
       'lib/taint/_contentTypeDetection.js',
+      'lib/taint/_securityHeaderOptions.js',
       'lib/async_hooks.js',
       'lib/assert.js',
       'lib/buffer.js',

--- a/node.gyp
+++ b/node.gyp
@@ -36,6 +36,7 @@
       'lib/_pathTraversalCheck.js',
       'lib/taint/_pg.js',
       'lib/taint/pg_lexer.js',
+      'lib/taint/_contentTypeDetection.js',
       'lib/async_hooks.js',
       'lib/assert.js',
       'lib/buffer.js',

--- a/test/parallel/test-http-1.0.js
+++ b/test/parallel/test-http-1.0.js
@@ -25,6 +25,10 @@ const assert = require('assert');
 const net = require('net');
 const http = require('http');
 
+// TaintNode
+http.ServerResponse.super_.prototype
+  .setSecurityHeaders({ 'addHeaders': false });
+
 const body = 'hello world\n';
 
 function test(handler, request_generator, response_validator) {

--- a/test/parallel/test-http-client-default-headers-exist.js
+++ b/test/parallel/test-http-client-default-headers-exist.js
@@ -25,6 +25,10 @@ const assert = require('assert');
 const http = require('http');
 const Countdown = require('../common/countdown');
 
+// TaintNode
+http.ServerResponse.super_.prototype
+  .setSecurityHeaders({ 'addHeaders': false });
+
 const expectedHeaders = {
   'DELETE': ['host', 'connection'],
   'GET': ['host', 'connection'],

--- a/test/parallel/test-http-client-headers-array.js
+++ b/test/parallel/test-http-client-headers-array.js
@@ -5,6 +5,10 @@ require('../common');
 const assert = require('assert');
 const http = require('http');
 
+// TaintNode
+http.ServerResponse.super_.prototype
+  .setSecurityHeaders({ 'addHeaders': false });
+
 function execute(options) {
   http.createServer(function(req, res) {
     const expectHeaders = {

--- a/test/parallel/test-http-content-length.js
+++ b/test/parallel/test-http-content-length.js
@@ -4,6 +4,10 @@ const assert = require('assert');
 const http = require('http');
 const Countdown = require('../common/countdown');
 
+// TaintNode
+http.ServerResponse.super_.prototype
+  .setSecurityHeaders({ 'addHeaders': false });
+
 const expectedHeadersMultipleWrites = {
   'connection': 'close',
   'transfer-encoding': 'chunked',

--- a/test/parallel/test-http-max-headers-count.js
+++ b/test/parallel/test-http-max-headers-count.js
@@ -24,6 +24,10 @@ require('../common');
 const assert = require('assert');
 const http = require('http');
 
+// TaintNode
+http.ServerResponse.super_.prototype
+  .setSecurityHeaders({ 'addHeaders': false });
+
 let requests = 0;
 let responses = 0;
 

--- a/test/parallel/test-http-raw-headers.js
+++ b/test/parallel/test-http-raw-headers.js
@@ -25,6 +25,10 @@ const assert = require('assert');
 
 const http = require('http');
 
+// TaintNode
+http.ServerResponse.super_.prototype
+  .setSecurityHeaders({ 'addHeaders': false });
+
 http.createServer(function(req, res) {
   const expectRawHeaders = [
     'Host',

--- a/test/parallel/test-http-remove-header-stays-removed.js
+++ b/test/parallel/test-http-remove-header-stays-removed.js
@@ -25,6 +25,10 @@ const assert = require('assert');
 
 const http = require('http');
 
+// TaintNode
+http.ServerResponse.super_.prototype
+  .setSecurityHeaders({ 'addHeaders': false });
+
 const server = http.createServer(function(request, response) {
   // removed headers should stay removed, even if node automatically adds them
   // to the output:

--- a/test/parallel/test-https-max-headers-count.js
+++ b/test/parallel/test-https-max-headers-count.js
@@ -13,6 +13,11 @@ const serverOptions = {
   cert: fixtures.readKey('agent1-cert.pem')
 };
 
+const http = require('http');
+// TaintNode
+http.ServerResponse.super_.prototype
+  .setSecurityHeaders({ 'addHeaders': false });
+
 let requests = 0;
 let responses = 0;
 

--- a/test/parallel/test-tls-over-http-tunnel.js
+++ b/test/parallel/test-tls-over-http-tunnel.js
@@ -33,6 +33,10 @@ const net = require('net');
 const http = require('http');
 const fixtures = require('../common/fixtures');
 
+// TaintNode
+http.ServerResponse.super_.prototype
+  .setSecurityHeaders({ 'addHeaders': false });
+
 let gotRequest = false;
 
 const key = fixtures.readKey('agent1-key.pem');

--- a/test/taint/test-content-type-sniffing.js
+++ b/test/taint/test-content-type-sniffing.js
@@ -1,0 +1,68 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const contentType = require('../../lib/taint/_contentTypeDetection');
+
+const data1 = '';
+assert.strictEqual(contentType.isHTML(data1), false);
+
+const data2 = '<html></html>';
+assert.strictEqual(contentType.isHTML(data2), true);
+
+const data3 = '    <html></html>';
+assert.strictEqual(contentType.isHTML(data3), true);
+
+const data4 = '<HtMl>';
+assert.strictEqual(contentType.isHTML(data4), true);
+
+const data5 = '<!DOCTYPE HTML';
+assert.strictEqual(contentType.isHTML(data5), true);
+
+const data6 = '<HTML';
+assert.strictEqual(contentType.isHTML(data6), true);
+
+const data7 = '<HEAD';
+assert.strictEqual(contentType.isHTML(data7), true);
+
+const data8 = '<SCRIPT';
+assert.strictEqual(contentType.isHTML(data8), true);
+
+const data9 = '<IFRAME';
+assert.strictEqual(contentType.isHTML(data9), true);
+
+const data10 = '<H1';
+assert.strictEqual(contentType.isHTML(data10), true);
+
+const data11 = '<DIV';
+assert.strictEqual(contentType.isHTML(data11), true);
+
+const data12 = '<FONT';
+assert.strictEqual(contentType.isHTML(data12), true);
+
+const data13 = '<TABLE';
+assert.strictEqual(contentType.isHTML(data13), true);
+
+const data14 = '<A';
+assert.strictEqual(contentType.isHTML(data14), true);
+
+const data15 = '<STYLE';
+assert.strictEqual(contentType.isHTML(data15), true);
+
+const data16 = '<TITLE';
+assert.strictEqual(contentType.isHTML(data16), true);
+
+const data17 = '<B';
+assert.strictEqual(contentType.isHTML(data17), true);
+
+const data18 = '<BODY';
+assert.strictEqual(contentType.isHTML(data18), true);
+
+const data19 = '<BR';
+assert.strictEqual(contentType.isHTML(data19), true);
+
+const data20 = '<P';
+assert.strictEqual(contentType.isHTML(data20), true);
+
+const data21 = '<!--';
+assert.strictEqual(contentType.isHTML(data21), true);

--- a/test/taint/test-http-security-headers.js
+++ b/test/taint/test-http-security-headers.js
@@ -1,0 +1,219 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const net = require('net');
+const http = require('http');
+
+// Set default security headers
+http.ServerResponse.super_.prototype
+  .setSecurityHeaders({ 'addHeaders': true,
+                        'headers':
+                        { 'x-powered-by': true,
+                          'expect-ct': true,
+                          'strict-transport-security': true,
+                          'referrer-policy': true,
+                          'x-dns-prefatch-control': true,
+                          'x-permitted-cross-domain-policies': false,
+                          'x-content-type-options': true,
+                          'content-security-policy': false,
+                          'x-download-options': true,
+                          'x-frame-options': true,
+                          'x-xss-protection': true,
+                          'feature-policy': false,
+                          'public-key-pins': false,
+                          'cache-control': false
+                        }
+  });
+
+const firstLine = 'HTTP/1.1 200 OK\r\n';
+
+const headers = 'Connection: keep-alive\r\n' +
+  'Content-Length: 0\r\n';
+
+const response1 = firstLine + headers + '\r\n';
+
+const response2 = firstLine +
+  'Content-Type: text/plain\r\n' +
+  'Expect-CT: max-age=86400; enforce\r\n' +
+  'Strict-Transport-Security: max-age=31536000; includeSubdomains\r\n' +
+  'Referrer-Policy: same-origin\r\n' +
+  'X-Content-Type-Options: nosniff\r\n' +
+  'X-DNS-Prefatch-Control: off\r\n' +
+  headers + '\r\n';
+
+const response3 = firstLine +
+  'Content-Type: text/html\r\n' +
+  'Expect-CT: max-age=86400; enforce\r\n' +
+  'Strict-Transport-Security: max-age=31536000; includeSubdomains\r\n' +
+  'Referrer-Policy: same-origin\r\n' +
+  'X-Content-Type-Options: nosniff\r\n' +
+  'X-DNS-Prefatch-Control: off\r\n' +
+  'X-Download-Options: noopen\r\n' +
+  'X-Frame-Options: deny\r\n' +
+  'X-XSS-Protection: 1; mode=block\r\n' +
+  headers + '\r\n';
+
+const response4 = firstLine +
+  'Referrer-Policy: origin\r\n' +
+  'Expect-CT: max-age=86400; enforce\r\n' +
+  'Strict-Transport-Security: max-age=31536000; includeSubdomains\r\n' +
+  'X-Content-Type-Options: nosniff\r\n' +
+  'X-DNS-Prefatch-Control: off\r\n' +
+  headers + '\r\n';
+
+const response5 = firstLine +
+  'Expect-CT: max-age=86400; enforce\r\n' +
+  'Strict-Transport-Security: max-age=31536000; includeSubdomains\r\n' +
+  'Referrer-Policy: same-origin\r\n' +
+  'X-Content-Type-Options: nosniff\r\n' +
+  'X-DNS-Prefatch-Control: off\r\n' +
+  headers + '\r\n';
+
+const response6 = firstLine +
+  'X-Foo: bar\r\n' +
+  'Expect-CT: max-age=86400; enforce\r\n' +
+  'Strict-Transport-Security: max-age=31536000; includeSubdomains\r\n' +
+  'Referrer-Policy: same-origin\r\n' +
+  'X-Content-Type-Options: nosniff\r\n' +
+  'X-DNS-Prefatch-Control: off\r\n' +
+  headers + '\r\n';
+
+const response7 = firstLine +
+  'Expect-CT: max-age=86400; enforce\r\n' +
+  'X-Content-Type-Options: nosniff\r\n' +
+  headers + '\r\n';
+
+const response8 = response7;
+
+let requests_sent = 0;
+let requests_received = 0;
+
+const server = http.createServer(function(req, res) {
+
+  // Deactivate Security Headers
+  if (requests_received === 0) {
+    res.setSecurityHeaders({ 'addHeaders': false });
+  }
+
+  // Content-Type text/plain
+  if (requests_received === 1) {
+    res.setSecurityHeaders({ 'addHeaders': true });
+    res.setHeader('Content-Type', 'text/plain');
+  }
+
+  // Content-Type text/html
+  if (requests_received === 2) {
+    res.setHeader('Content-Type', 'text/html');
+  }
+
+  if (requests_received === 3) {
+    res.setHeader('Referrer-Policy', 'origin');
+  }
+
+  if (requests_received === 4) {
+    res.setHeader('X-Powered-By', 'Taint-Node');
+  }
+
+  if (requests_received === 5) {
+    res.setHeader('X-Foo', 'bar');
+  }
+
+  // Specific Security Headers
+  if (requests_received === 6) {
+    res.setSecurityHeaders({ 'addHeaders': true,
+                             'headers':
+                             { 'x-powered-by': false,
+                               'expect-ct': true,
+                               'strict-transport-security': false,
+                               'referrer-policy': false,
+                               'x-dns-prefatch-control': false,
+                               'x-permitted-cross-domain-policies': false,
+                               'x-content-type-options': true,
+                               'content-security-policy': false,
+                               'x-download-options': false,
+                               'x-frame-options': false,
+                               'x-xss-protection': true,
+                               'feature-policy': false,
+                               'public-key-pins': false,
+                               'cache-control': false
+                             }
+    });
+  }
+
+  // Security Header Prototype should be stored
+  if (requests_received === 7)
+    this.close();
+
+  res.sendDate = false;
+  res.end();
+  requests_received += 1;
+});
+
+server.listen(0);
+
+server.on('listening', function() {
+  const c = net.createConnection(this.address().port);
+  c.setEncoding('utf8');
+
+  c.on('connect', function() {
+    c.write('GET / HTTP/1.1\r\n\r\n');
+    requests_sent += 1;
+  });
+
+  c.on('data', function(chunk) {
+    const server_response = chunk;
+
+    // Deactivated Security Headers
+    if (requests_sent === 1) {
+      assert.strictEqual(server_response, response1);
+    }
+
+    // Default Security Headers (non-http)
+    if (requests_sent === 2) {
+      assert.strictEqual(server_response, response2);
+    }
+
+    // Default Security Headers (http)
+    if (requests_sent === 3) {
+      assert.strictEqual(server_response, response3);
+    }
+
+    // Do not overwrite exisitng security headers
+    if (requests_sent === 4) {
+      assert.strictEqual(server_response, response4);
+    }
+
+    // Remove powered-by header
+    if (requests_sent === 5) {
+      assert.strictEqual(server_response, response5);
+    }
+
+    // Keep other headers
+    if (requests_sent === 6) {
+      assert.strictEqual(server_response, response6);
+    }
+
+    // Sepcific set of security headers
+    if (requests_sent === 7) {
+      assert.strictEqual(server_response, response7);
+    }
+
+    // Security headers should be stored over multiple responses
+    if (requests_sent === 8) {
+      assert.strictEqual(server_response, response8);
+      c.end();
+      return;
+    }
+
+    c.write('GET / HTTP/1.1\r\n\r\n');
+    requests_sent += 1;
+  });
+
+  c.on('end', function() {
+
+  });
+
+  c.on('close', function() {
+
+  });
+});


### PR DESCRIPTION
<!-- Please provide a description and review the requirements below -->

##### Description
Implemented a feature that automatically sets a specific set of security headers to each HTTP response. This feature can be configured via the _package.json_, the environment variable _SECURITYHEADER_ or directly on the _OutgoingMessage_ prototype.



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] `make -j4 test-taint` (UNIX) or `vcbuild test-taint` (Windows) passes
- [ ] Documentation is changed or added in [GitHub Wiki](https://github.com/SAP/node-rasp/wiki)
- [ ] ~~Taint API version updated in ``src/node_version.h`` and ``README.md`` according to semantic versioning rules~~
